### PR TITLE
Permit using vpcNames in BlackHole Routes to enhance readability

### DIFF
--- a/config/config-walkthrough.yaml
+++ b/config/config-walkthrough.yaml
@@ -316,10 +316,12 @@ transitGateways:
     # be tossed into the garbage.  Use this when you have some 'must not' rules to enforce.  Ie: Blacklisting all Production
     # CIDR Addresses on your Development VPC is a good idea!  That way traffic can never get there regardless of routing rules.
     blackholeRoutes:
-        # REQUIRED: The name of the thing we're routing from.  This can be a VPC, or a Provider name.
+        # REQUIRED: The name of the thing we're setting the blackhole for.  This can be a VPC, or a Provider name.
       - vpcName: workloadTwo
-        # REQUIRED: CIDR addresses to discard traffic from
+        # REQUIRED: CIDR addresses to discard traffic from OR the name of a VPC from the `vpc:` section above.  When a vpcName
+        # is specified the vpcCidr is used from the configuration definition above.
         blackholeCidrs:
         - 192.168.168.0/24
+        - workload
         # More blackholeCidrs supported
       # More Lists of Objects supported.

--- a/config/sample-central-egress-inspected.vpcBuilder.yaml
+++ b/config/sample-central-egress-inspected.vpcBuilder.yaml
@@ -52,7 +52,7 @@ transitGateways:
     blackholeRoutes:
       - vpcName: isolatedVpcOne
         blackholeCidrs:
-          - 10.11.0.0/19
+          - isolatedVpcTwo
       - vpcName: isolatedVpcTwo
         blackholeCidrs:
-          - 10.10.0.0/19
+          - isolatedVpcOne

--- a/test/config-parser.test.ts
+++ b/test/config-parser.test.ts
@@ -602,6 +602,28 @@ test("RouteNamingSanity", () => {
   })
 });
 
+test("BlackHoleCidrValue", () => {
+
+  const configContents: any = minimumConfig();
+  configContents.transitGateways = {
+    testing: {
+      style: "transitGateway",
+      tgwDescription: "testing",
+    },
+  };
+  // Invalid CIDR, invalid VPCName
+  configContents.transitGateways["testing"]["blackholeRoutes"] = [
+    {
+      vpcName: "dev",
+      blackholeCidrs: [ "10.1.0.0" ],
+    },
+  ]
+    let config = new ConfigParser({ configContents: configContents });
+    expect(() => config.parse()).toThrow(
+        `blackholeRoutes contains blackholeCidr with value 10.1.0.0.  Not a valid CIDR Address or Vpc Name within the 'vpc:' configuration section.`
+    );
+});
+
 test("RouteToInternetWithNoInternetProviderInVpc", () => {
   const configContents = minimumConfig();
   configContents.providers = {


### PR DESCRIPTION
Address Enhancement request #17 

Can optionally specify an existing VPC name from the `vpc:` section and it's `vpcCidr:` will be substituted automatically.
