### PR TITLE
Corrected RAM Share names for subnets to include the VPC Name

### DIFF
--- a/lib/vpc-workload-isolated-stack.ts
+++ b/lib/vpc-workload-isolated-stack.ts
@@ -60,7 +60,7 @@ export class VpcWorkloadIsolatedStack extends BuilderVpc {
       if (createSubnet.sharedWith) {
         new ram.CfnResourceShare(this, `RamShare${createSubnet.name}`, {
           allowExternalPrincipals: false,
-          name: `Share-${createSubnet.name}`,
+          name: `Share-${this.name}`,
           permissionArns: [
             "arn:aws:ram::aws:permission/AWSRAMDefaultPermissionSubnet",
           ],

--- a/lib/vpc-workload-public-stack.ts
+++ b/lib/vpc-workload-public-stack.ts
@@ -52,7 +52,7 @@ export class VpcWorkloadPublicStack extends BuilderVpc {
       if (createSubnet.sharedWith) {
         new ram.CfnResourceShare(this, `RamShare${createSubnet.name}`, {
           allowExternalPrincipals: false,
-          name: `Share-${createSubnet.name}`,
+          name: `Share-${this.name}`,
           permissionArns: [
             "arn:aws:ram::aws:permission/AWSRAMDefaultPermissionSubnet",
           ],


### PR DESCRIPTION
Fix for bug #18 

RAM Share names now include the VPC Name from the configuration file instead of just the VPC Style