### PR TITLE
Bug fix for return path for DX GW propagations

### DIFF
--- a/lib/direct-connect-gateway-stack.ts
+++ b/lib/direct-connect-gateway-stack.ts
@@ -24,7 +24,7 @@ export class DirectConnectGatewayStack extends BuilderDxGw {
     super(scope, id, props);
 
     this.name = `${props.namePrefix}-dxgw`.toLowerCase();
-
+    this.withTgw = true;
     this.tgw = {
       attrId: this.props.existingTransitGatewayId
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-vpc-builder-cdk",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "bin": {
     "vpc-builder": "bin/vpc-builder.js"
   },


### PR DESCRIPTION
Missing value for `withTgw` causes return path to be missed for DX GW Model.