### PR TITLE
Ability to pass a Permission boundary name via the context on the command line

### DIFF
--- a/bin/vpc-builder.ts
+++ b/bin/vpc-builder.ts
@@ -9,9 +9,10 @@ import { Stack } from "aws-cdk-lib"
     const cdkApp = stackBuilder.stackMapper.app;
 
     const configFile = cdkApp.node.tryGetContext("config");
+    const permissionsBoundary = cdkApp.node.tryGetContext("permissions_boundary");
     // If a configuration file is provided we will use it to build our stacks
     if (configFile) {
-      stackBuilder.configure(configFile);
+      stackBuilder.configure(configFile, undefined, permissionsBoundary);
       await stackBuilder.build();
     } else {
       // When no configuration context provided, we will warn but not fail.  This allows 'cdk bootstrap', 'cdk help'

--- a/lib/stack-builder.ts
+++ b/lib/stack-builder.ts
@@ -109,7 +109,9 @@ export class StackBuilderClass {
       configFilename: configFilename,
       configContents: configContents,
     });
-    this.permissionsBoundary = cdk.PermissionsBoundary.fromName(permissionsBoundary);
+    if (permissionsBoundary) {
+      this.permissionsBoundary = cdk.PermissionsBoundary.fromName(permissionsBoundary);
+    }
     try {
       this.configParser.parse();
       this.c = this.configParser.config;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

One way to resolve the issue with the permission boundary, is to update the cdk.json, and include a permission boundary here on this level. This is well documented and works well.

I have several accounts, some of which use no permission boundary, some have permission boundaries with different names. Hence I want to be able to pass the permission boundary. In this PR is have done this by passing the name as an additional parameter in the context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
